### PR TITLE
Fix audio incall for samsung devices chipset msm8916

### DIFF
--- a/src/com/android/server/telecom/CallAudioModeStateMachine.java
+++ b/src/com/android/server/telecom/CallAudioModeStateMachine.java
@@ -154,9 +154,13 @@ public class CallAudioModeStateMachine extends StateMachine {
         public void enter() {
             if (mIsInitialized) {
                 Log.i(LOG_TAG, "Abandoning audio focus: now UNFOCUSED");
+                boolean setRealcallAudioParams = SystemProperties
+                    .getBoolean("ro.telephony.samsung.realcall", false);
                 mAudioManager.abandonAudioFocusForCall();
                 mAudioManager.setMode(AudioManager.MODE_NORMAL);
-
+                if (setRealcallAudioParams) {
+                    mAudioManager.setParameters("realcall=off");
+                }
                 mMostRecentMode = AudioManager.MODE_NORMAL;
                 mCallAudioManager.setCallAudioRouteFocusState(CallAudioRouteStateMachine.NO_FOCUS);
             }
@@ -295,6 +299,8 @@ public class CallAudioModeStateMachine extends StateMachine {
             Log.i(LOG_TAG, "Audio focus entering SIM CALL state");
             boolean setMsimAudioParams = SystemProperties
                     .getBoolean("ro.multisim.set_audio_params", false);
+            boolean setRealcallAudioParams = SystemProperties
+                    .getBoolean("ro.telephony.samsung.realcall", false);
             Call call = mCallAudioManager.getForegroundCall();
 
             mAudioManager.requestAudioFocusForCall(AudioManager.STREAM_VOICE_CALL,
@@ -310,6 +316,9 @@ public class CallAudioModeStateMachine extends StateMachine {
                     mAudioManager.setParameters("phone_type=cp1");
                 } else if (phoneId == 1) {
                     mAudioManager.setParameters("phone_type=cp2");
+                }
+                if(setRealcallAudioParams){
+                    mAudioManager.setParameters("realcall=on");
                 }
             }
 


### PR DESCRIPTION
This corrects audio calls to Samsung devices msm8916 chipset, has no effect on other devices since it is configured in your device tree.